### PR TITLE
Allow superclasses to replace subclasses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.0.0
-Date: 2021-01-07
+Version: 4.0.0.9001
+Date: 2021-01-19
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2697,7 +2697,10 @@ setMethod( # because R doesn't allow S3-style [[<- for S4 classes
         stop("All cells in the object being added must match the cells in this object", call. = FALSE)
       }
       # Ensure we're not duplicating object names
-      if (!is.null(x = FindObject(object = x, name = i)) && !inherits(x = value, what = c(class(x = x[[i]]), 'NULL'))) {
+      duplicate <- !is.null(x = FindObject(object = x, name = i)) &&
+        !inherits(x = value, what = c(class(x = x[[i]]), 'NULL')) &&
+        !inherits(x = x[[i]], what = class(x = value))
+      if (isTRUE(x = duplicate)) {
         stop(
           "This object already contains ",
           i,


### PR DESCRIPTION
For example, allows `Assay` object to replace `SCTAssay` or `ChromatinAssay` objects