### PR TITLE
Preserve row and column names when creating an Assay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.0.0.9001
-Date: 2021-01-19
+Version: 4.0.0.9002
+Date: 2021-02-12
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/R/assay.R
+++ b/R/assay.R
@@ -67,6 +67,7 @@ Assay <- setClass(
 #' new object with a lower cutoff.
 #' @param min.features Include cells where at least this many features are
 #' detected.
+#' @param ... Arguments passed to \code{\link{as.sparse}}
 #'
 #' @return A \code{\link{Assay}} object
 #'
@@ -91,7 +92,8 @@ CreateAssayObject <- function(
   counts,
   data,
   min.cells = 0,
-  min.features = 0
+  min.features = 0,
+  ...
 ) {
   if (missing(x = counts) && missing(x = data)) {
     stop("Must provide either 'counts' or 'data'")
@@ -125,11 +127,7 @@ CreateAssayObject <- function(
       stop("No feature names (rownames) names present in the input matrix")
     }
     if (!inherits(x = counts, what = 'dgCMatrix')) {
-      rn.stash <- rownames(x = counts)
-      cn.stash <- colnames(x = counts)
-      counts <- as(object = as.matrix(x = counts), Class = 'dgCMatrix')
-      rownames(x = counts) <- rn.stash
-      colnames(x = counts) <- cn.stash
+      counts <- as.sparse(x = counts, ...)
     }
     # Filter based on min.features
     if (min.features > 0) {

--- a/R/assay.R
+++ b/R/assay.R
@@ -125,7 +125,11 @@ CreateAssayObject <- function(
       stop("No feature names (rownames) names present in the input matrix")
     }
     if (!inherits(x = counts, what = 'dgCMatrix')) {
+      rn.stash <- rownames(x = counts)
+      cn.stash <- colnames(x = counts)
       counts <- as(object = as.matrix(x = counts), Class = 'dgCMatrix')
+      rownames(x = counts) <- rn.stash
+      colnames(x = counts) <- cn.stash
     }
     # Filter based on min.features
     if (min.features > 0) {

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -909,6 +909,10 @@ Command.Seurat <- function(object, command = NULL, value = NULL, ...) {
   return(params[[value]])
 }
 
+#' @param row.names When \code{counts} is a \code{data.frame} or
+#' \code{data.frame}-derived object: an optional vector of feature names to be
+#' used
+#'
 #' @rdname CreateSeuratObject
 #' @method CreateSeuratObject default
 #' @export
@@ -922,6 +926,7 @@ CreateSeuratObject.default <- function(
   meta.data = NULL,
   min.cells = 0,
   min.features = 0,
+  row.names = NULL,
   ...
 ) {
   if (!is.null(x = meta.data)) {
@@ -932,7 +937,8 @@ CreateSeuratObject.default <- function(
   assay.data <- CreateAssayObject(
     counts = counts,
     min.cells = min.cells,
-    min.features = min.features
+    min.features = min.features,
+    row.names = row.names
   )
   if (!is.null(x = meta.data)) {
     common.cells <- intersect(

--- a/R/utils.R
+++ b/R/utils.R
@@ -232,12 +232,21 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
 # Methods for Seurat-defined generics
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+#' @param row.names \code{NULL} or a character vector giving the row names for
+#' the data; missing values are not allowed
+#'
 #' @rdname as.sparse
 #' @export
 #' @method as.sparse data.frame
 #'
-as.sparse.data.frame <- function(x, ...) {
+as.sparse.data.frame <- function(x, row.names = NULL, ...) {
   CheckDots(...)
+  dnames <- list(row.names %||% rownames(x = x), colnames(x = x))
+  if (length(x = dnames[[1]]) != nrow(x = x)) {
+    stop("Differing numbers of rownames and rows", call. = FALSE)
+  }
+  x <- as.data.frame(x = x)
+  dimnames(x = x) <- dnames
   return(as.sparse(x = as.matrix(x = x)))
 }
 

--- a/man/CreateAssayObject.Rd
+++ b/man/CreateAssayObject.Rd
@@ -4,7 +4,7 @@
 \alias{CreateAssayObject}
 \title{Create an Assay object}
 \usage{
-CreateAssayObject(counts, data, min.cells = 0, min.features = 0)
+CreateAssayObject(counts, data, min.cells = 0, min.features = 0, ...)
 }
 \arguments{
 \item{counts}{Unnormalized data such as raw counts or TPMs}
@@ -17,6 +17,8 @@ new object with a lower cutoff.}
 
 \item{min.features}{Include cells where at least this many features are
 detected.}
+
+\item{...}{Arguments passed to \code{\link{as.sparse}}}
 }
 \value{
 A \code{\link{Assay}} object

--- a/man/CreateSeuratObject.Rd
+++ b/man/CreateSeuratObject.Rd
@@ -25,6 +25,7 @@ CreateSeuratObject(
   meta.data = NULL,
   min.cells = 0,
   min.features = 0,
+  row.names = NULL,
   ...
 )
 
@@ -70,6 +71,10 @@ new object with a lower cutoff.}
 
 \item{min.features}{Include cells where at least this many features are
 detected.}
+
+\item{row.names}{When \code{counts} is a \code{data.frame} or
+\code{data.frame}-derived object: an optional vector of feature names to be
+used}
 }
 \value{
 A \code{\link{Seurat}} object

--- a/man/as.sparse.Rd
+++ b/man/as.sparse.Rd
@@ -9,7 +9,7 @@
 \usage{
 as.sparse(x, ...)
 
-\method{as.sparse}{data.frame}(x, ...)
+\method{as.sparse}{data.frame}(x, row.names = NULL, ...)
 
 \method{as.sparse}{Matrix}(x, ...)
 
@@ -19,6 +19,9 @@ as.sparse(x, ...)
 \item{x}{An object}
 
 \item{...}{Arguments passed to other methods}
+
+\item{row.names}{\code{NULL} or a character vector giving the row names for
+the data; missing values are not allowed}
 }
 \value{
 A sparse representation of the input data


### PR DESCRIPTION
Sometimes row/column names are lost when converting counts to a `dgCMatrix`, depending on the starting object class (eg, happens for `data.table`). This ensures rownames and colnames are not lost.

https://github.com/satijalab/seurat/issues/4063