### PR TITLE
improve error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.0.0.9003
-Date: 2021-02-12
+Version: 4.0.0.9004
+Date: 2021-02-19
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2750,7 +2750,7 @@ setMethod( # because R doesn't allow S3-style [[<- for S4 classes
           class(x = x[[i]]),
           ", so ", 
           i, 
-          " cannot be used for ", 
+          " cannot be used for a ", 
           class(x = value),
           call. = FALSE
         )

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2748,7 +2748,10 @@ setMethod( # because R doesn't allow S3-style [[<- for S4 classes
             no = ' '
           ),
           class(x = x[[i]]),
-          "; duplicate names are not allowed",
+          ", so ", 
+          i, 
+          " cannot be used for ", 
+          class(x = value),
           call. = FALSE
         )
       }


### PR DESCRIPTION
```
pbmc_small
pbmc_small <- NormalizeData(pbmc_small)%>%FindVariableFeatures()%>%ScaleData()%>%RunPCA()
pbmc_small <- FindNeighbors(pbmc_small, dims = 1:30, return.neighbor = T)
pbmc_small <- FindNeighbors(pbmc_small, dims = 1:30, return.neighbor = F)
```
It changes the error message from
```
Error: This object already contains RNA_nn as a Neighbor; duplicate names are not allowed
```
to
```
Error: This object already contains RNA_nn as a Neighbor, so RNA_nn cannot be used for a Graph
```