### PR TITLE
Throw a warning message when pulling metadata with the same name as a feature

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -347,6 +347,17 @@ FetchData <- function(object, vars, cells = NULL, slot = 'data') {
   # Pull vars from object metadata
   meta.vars <- vars[vars %in% colnames(x = object[[]]) & !(vars %in% names(x = data.fetched))]
   data.fetched <- c(data.fetched, object[[meta.vars]][cells, , drop = FALSE])
+  meta.default <- meta.vars[meta.vars %in% rownames(x = GetAssayData(object = object, slot = slot))]
+  if (length(x = meta.default)) {
+    warning(
+      "The following variables were found in both object metadata and the default assay: ",
+      paste0(meta.default, collapse = ", "),
+      "\nReturning metadata; if you want the feature, please use the assay's key (eg. ",
+      paste0(Key(object = object[[DefaultAssay(object = object)]]), meta.default[1]),
+      ")",
+      call. = FALSE
+    )
+  }
   # Pull vars from the default assay
   default.vars <- vars[vars %in% rownames(x = GetAssayData(object = object, slot = slot)) & !(vars %in% names(x = data.fetched))]
   data.fetched <- c(


### PR DESCRIPTION
In `FetchData`, if a user requests a variable that's present in both metadata and the default assay, throw a warning instead of silently returning the metadata

```R
pbmc_small[["MS4A1"]] <- "a"
head(FetchData(pbmc_small, "MS4A1"))
               MS4A1
ATGCCAGAACGACT     a
CATGGCCTGTGCAT     a
GAACCTGATGAACC     a
TGACTGGATTCTCA     a
AGTCAGACTGCACA     a
TCTGATACACGTGT     a
Warning message:
The following variables were found in both object metadata and the default assay: MS4A1
Returning the metadata; if you want the feature, please use the assay's key (eg. rna_MS4A1) 
```