### PR TITLE
Fix issue with CheckDots

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -495,7 +495,7 @@ CheckDots <- function(..., fxns = NULL) {
         paste(unused, collapse = ', ')
       )
       switch(
-        EXPR = getOption(x = "Seurat.checkdots"),
+        EXPR = getOption(x = "Seurat.checkdots", default = 'warn'),
         "warn" = warning(msg, call. = FALSE, immediate. = TRUE),
         "stop" = stop(msg),
         "silent" = NULL,


### PR DESCRIPTION
Provide default when option `Seurat.checkdots` is not set

fixes #15