### PR TITLE
Set key when creating Seurat objects from Assays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.0.3
-Date: 2021-11-10
+Version: 4.0.3.9000
+Date: 2021-11-19
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
@@ -29,7 +29,7 @@ BugReports:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Depends:
   R (>= 4.0.0)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+## Changed
+- `CreateSeuratObject.Assay` sets Assay key when not present (#29)
+
 # SeuratObject 4.0.3
 
 ## Changed

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1056,6 +1056,10 @@ CreateSeuratObject.Assay <- function(
       meta.data <- new.meta.data
     }
   }
+  # Check assay key
+  if (!length(x = Key(object = counts)) || !nchar(x = Key(object = counts))) {
+    Key(object = counts) <- UpdateKey(key = tolower(x = assay))
+  }
   assay.list <- list(counts)
   names(x = assay.list) <- assay
   # Set idents

--- a/man/SeuratObject-package.Rd
+++ b/man/SeuratObject-package.Rd
@@ -6,14 +6,7 @@
 \alias{SeuratObject-package}
 \title{SeuratObject: Data Structures for Single Cell Data}
 \description{
-Defines S4 classes for single-cell genomic data and associated
-  information, such as dimensionality reduction embeddings, nearest-neighbor
-  graphs, and spatially-resolved coordinates. Provides data access methods and
-  R-native hooks to ensure the Seurat object is familiar to other R users. See
-  Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>,
-  Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>,
-  and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for
-  more details.
+Defines S4 classes for single-cell genomic data and associated information, such as dimensionality reduction embeddings, nearest-neighbor graphs, and spatially-resolved coordinates. Provides data access methods and R-native hooks to ensure the Seurat object is familiar to other R users. See Satija R, Farrell J, Gennert D, et al (2015) <doi:10.1038/nbt.3192>, Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details.
 }
 \seealso{
 Useful links:

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // GraphToNeighborHelper
 List GraphToNeighborHelper(Eigen::SparseMatrix<double> mat);
 RcppExport SEXP _SeuratObject_GraphToNeighborHelper(SEXP matSEXP) {


### PR DESCRIPTION
Fix issue where keys aren't being set when creating a Seurat object from an Assay
`CreateSeuratObject.Assay` now checks that the key of an assay has length and nchar
If not, creates a key from the assay name