### PR TITLE
Fix website address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: Defines S4 classes for single-cell genomic data and associated
   Macosko E, Basu A, Satija R, et al (2015) <doi:10.1016/j.cell.2015.05.002>,
   and Stuart T, Butler A, et al (2019) <doi:10.1016/j.cell.2019.05.031> for
   more details.
-URL: https://satijalab.org/seurat,
+URL: https://mojaveazure.github.io/seurat-object,
       https://github.com/mojaveazure/seurat-object
 BugReports:
       https://github.com/mojaveazure/seurat-object/issues


### PR DESCRIPTION
Current CRAN website points to https://satijalab.org/seurat/, which I _believe_ causes pkgdown to create incorrect links to reexported functions in Seurat (eg, https://satijalab.org/seurat/articles/reference/Embeddings.html)