### PR TITLE
Add pkgdown url

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://mojaveazure.github.io/seurat-object/
 destination: docs
 
 template:


### PR DESCRIPTION
According to https://pkgdown.r-lib.org/articles/linking.html, auto-linking of function documentation across pkgdown websites requires that the website is listed in the url field of the DESCRIPTION file, _and_ in the `_pkgdown.yaml` file. This is related to https://github.com/mojaveazure/seurat-object/pull/30 and should solve issues with broken function documentation links in the Seurat website.