### PR TITLE
fix the error message

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1888,7 +1888,7 @@ WhichCells.Seurat <- function(
         "Cannot find the following identities in the object: ",
         paste(
           idents[!idents %in% levels(x = Idents(object = object))],
-          sep = ', '
+          collapse = ', '
         )
       )
     }


### PR DESCRIPTION
idents=c(1,2,40, 41, 42)
x=1:30

# not good
stop(
  "Cannot find the following identities in the object: ",
  paste(
    idents[!idents %in% x],
    sep = ', '
  )
) 
#404142

# good
stop(
  "Cannot find the following identities in the object: ",
  paste(
    idents[!idents %in% x],
    collapse = ', '
  ) 
)
#40, 41, 42