### PR TITLE
Allow as.sparse conversion of character matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.1.2.9004
-Date: 2022-10-25
+Version: 4.1.2.9005
+Date: 2022-11-04
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/R/utils.R
+++ b/R/utils.R
@@ -598,6 +598,11 @@ as.sparse.Matrix <- function(x, ...) {
 #' @method as.sparse matrix
 #'
 as.sparse.matrix <- function(x, ...) {
+  if (is.character(x = x)) {
+    dnames <- dimnames(x = x)
+    x <- matrix(data = as.numeric(x = x), ncol = length(x = dnames[[2]]))
+    dimnames(x = x) <- dnames
+  }
   x <- as(object = x, Class = "Matrix")
   return(as.sparse.Matrix(x, ...))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -600,7 +600,8 @@ as.sparse.Matrix <- function(x, ...) {
 as.sparse.matrix <- function(x, ...) {
   if (is.character(x = x)) {
     dnames <- dimnames(x = x)
-    x <- matrix(data = as.numeric(x = x), ncol = length(x = dnames[[2]]))
+    nc <- ncol(x = x)
+    x <- matrix(data = as.numeric(x = x), ncol = nc)
     dimnames(x = x) <- dnames
   }
   x <- as(object = x, Class = "Matrix")


### PR DESCRIPTION
This add a check if the contents of a matrix is character, and if so convert to numeric before proceeding with conversion to a sparse matrix.

Example:

```r
library(SeuratObject)
a <- matrix(data = as.character(1:100), ncol = 10)
as.sparse(a)
```

Fixes https://github.com/satijalab/seurat/issues/6620