### PR TITLE
fix VariableFeaturePlot command search bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9044
+Version: 4.9.9.9048
 Date: 2022-12-01
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1719,7 +1719,7 @@ HVFInfo.Seurat <- function(
     cmds <- apply(
       X = expand.grid(
         c('FindVariableFeatures', 'SCTransform'),
-        FilterObjects(object = object, classes.keep = 'Assay')
+        FilterObjects(object = object, classes.keep = c('Assay', 'Assay5'))
       ),
       MARGIN = 1,
       FUN = paste,


### PR DESCRIPTION
VariableFeaturePlots using v5 assays weren't making past an initial check because the command search didn't consider commands run on v5 assays