### PR TITLE
Fix FetchData.StdAssay column order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9048
+Version: 4.9.9.9049
 Date: 2022-12-06
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -815,7 +815,7 @@ FetchData.StdAssay <- function(
       layer = lyr,
       cells = lcells,
       features = lvars
-    ))
+    ))[, lvars]
   }
   # Clean out missing cells from the expression matrix
   if (isTRUE(x = clean)) {


### PR DESCRIPTION
This is an older fix that was never merged in to feat/standard. Often times expression data returned by FetchData would contain the correct numbers but with gene names mixed up for v5 assays.
