### PR TITLE
Bugfix to CellsByIdentities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.1.3
-Date: 2022-11-07
+Version: 4.1.3.9001
+Date: 2023-03-03
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+## Changes
+- Fixes for `CellsByIdentities` (#80)
+
 # SeuratObject 4.1.3
 ## Changes
 - Move {rgeos} to Suggests; segmentation simplification now requires {regos} to be installed manually

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -232,7 +232,7 @@ CellsByIdentities <- function(
     USE.NAMES = TRUE
   )
   if (any(is.na(x = Idents(object = object)[cells]))) {
-    cells.idents["NA"] <- names(x = which(x = is.na(x = Idents(object = object)[cells])))
+    cells.idents[["NA"]] <- names(x = which(x = is.na(x = Idents(object = object)[cells])))
   }
   return(cells.idents)
 }


### PR DESCRIPTION
I think this is broken, at least in some R versions. If your object has more than one cell with NA as the ident you get an error like:

Warning message:
  In cells.idents["NA"] <- names(x = which(x = is.na(x = Idents(object = object)[cells]))) :
  number of items to replace is not a multiple of replacement length

You can repro this with the following:
```
library(Seurat)

dat <- matrix(1:100, ncol = 10, dimnames = list(LETTERS[1:10], LETTERS[11:20]))
df <- data.frame(x = LETTERS[5:14], field <- factor(c(rep('AA', 5), rep('BB', 5))), row.names = LETTERS[11:20])
so <- Seurat::CreateSeuratObject(dat, meta.data = df)

# Set NAs. These are cells N and O:
so@meta.data$field[4:5] <- NA
Idents(so) <- 'field'
Idents(so)

# This vector has two cells with NAs. If you have a single NA cell it will work:
cells <- c('M', 'N', 'O')
x <- Seurat::CellsByIdentities(
  object = so,
  idents = NULL,
  cells = cells
)
```

The problem is that R assignment with a single bracket fails when you're trying to assign a vector (hence why you need two or more NA cells).