### PR TITLE
v5 --> v3 assays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9063
+Version: 4.9.9.9064
 Date: 2023-01-30
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay.R
+++ b/R/assay.R
@@ -1489,9 +1489,18 @@ setAs(
                              layers = i, 
                              new = i) 
       }
+      if(i == "data") {
+        if (isTRUE(Layers(object = from, search = i) == "scale.data")){
+          warning("No counts or data slot in object. Setting 'data' slot using", 
+                  " data from 'scale.data' slot. To recreate 'data' slot, you", 
+                  " must set and normalize data from a 'counts' slot.", 
+                  call. = FALSE)
+        }
+      }
       adata <- LayerData(object = from, layer = i)
       if(inherits(x = adata, what = "IterableMatrix")) {
-        warning("Converting IterableMatrix to sparse dgCMatrix")
+        warning("Converting IterableMatrix to sparse dgCMatrix", 
+                call. = FALSE)
         adata <- as(object = adata, Class = "dgCMatrix")
       }
       data.list[[i]] <- adata 
@@ -1509,7 +1518,7 @@ setAs(
       key = Key(object = from)
     )
     # Add feature-level meta data
-    to@meta.features <- from[]
+    suppressWarnings(to[] <- from[])
     mdata <- Misc(object = from)
     for (i in names(x = mdata)) {
       Misc(object = to, slot = i) <- mdata[[i]]

--- a/R/assay.R
+++ b/R/assay.R
@@ -1478,6 +1478,46 @@ tail.Assay <- function(x, n = 10L, ...) {
 # S4 methods
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+setAs(
+  from = 'Assay5',
+  to = 'Assay',
+  def = function(from) {
+    data.list <- c()
+    for (i in c('counts', 'data', 'scale.data')) {
+      if (length(Layers(object = from, search = i)) > 1) {
+          from <- JoinLayers(object = from, 
+                             layers = i, 
+                             new = i) 
+      }
+      adata <- LayerData(object = from, layer = i)
+      if(inherits(x = adata, what = "IterableMatrix")) {
+        warning("Converting IterableMatrix to sparse dgCMatrix")
+        adata <- as(object = adata, Class = "dgCMatrix")
+      }
+      data.list[[i]] <- adata 
+    }
+    if (IsMatrixEmpty(x = data.list[["data"]])){
+      data.list[["data"]] <- data.list[["counts"]]
+    }
+    to <- new(
+      Class = 'Assay',
+      counts = data.list[["counts"]], 
+      data = data.list[["data"]], 
+      scale.data = data.list[["scale.data"]],
+      assay.orig = DefaultAssay(object = from) %||% character(length = 0L),
+      meta.features = data.frame(row.names = rownames(x = data.list[["data"]])), 
+      key = Key(object = from)
+    )
+    # Add feature-level meta data
+    to@meta.features <- from[]
+    mdata <- Misc(object = from)
+    for (i in names(x = mdata)) {
+      Misc(object = to, slot = i) <- mdata[[i]]
+    }
+    return(to)
+  }
+)
+
 #' @rdname sub-.Assay
 #'
 #' @order 2

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1117,7 +1117,7 @@ LayerData.StdAssay <- function(
   layer_name <- layer[1L] %||% DefaultLayer(object = object)[1L]
   layer <- Layers(object = object, search = layer)[1L]
   # layer <- match.arg(arg = layer, choices = Layers(object = object))
-  if (is.na(layer)) {
+  if (is.null(layer)) {
     msg <- paste("Layer", sQuote(x = layer_name), "is empty")
     opt <- getOption(x = "Seurat.object.assay.v3.missing_layer",
                      default = Seurat.options$Seurat.object.assay.v3.missing_layer)

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1117,7 +1117,7 @@ LayerData.StdAssay <- function(
   layer_name <- layer[1L] %||% DefaultLayer(object = object)[1L]
   layer <- Layers(object = object, search = layer)[1L]
   # layer <- match.arg(arg = layer, choices = Layers(object = object))
-  if (is.null(layer)) {
+  if (is.null(layer) || is.na(layer)) {
     msg <- paste("Layer", sQuote(x = layer_name), "is empty")
     opt <- getOption(x = "Seurat.object.assay.v3.missing_layer",
                      default = Seurat.options$Seurat.object.assay.v3.missing_layer)


### PR DESCRIPTION
Method
- Gets data from each of 'counts', 'data', 'scale.data'
   - `JoinLayers` if necessary
   -  Converts`IterableMatrix` to `dgCMatrix`
- Makes new assay class
- adds feature level metadata and miscellaneous data 



Tested on 
    - BPCells
    - Split layers
    - Different number of features per layer
    - Only counts layer (no data or scale.data) 