### PR TITLE
Use newer version of Matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.1.3.9001
-Date: 2023-03-03
+Version: 4.1.3.9002
+Date: 2023-03-08
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
@@ -38,7 +38,7 @@ Imports:
     future.apply,
     grDevices,
     grid,
-    Matrix (>= 1.5.0),
+    Matrix (>= 1.5.3),
     methods,
     progressr,
     Rcpp (>= 1.0.5),


### PR DESCRIPTION
`CsparseMatrices` generated by Matrix v1.5.3 are validated using `CsparseMatrix_validate`, which is not present in older version of Matrix

This sets the minimum version of Matrix to 1.5.3 to prevent these issues