### PR TITLE
Allow for filtering of BPCells matrices in CreateSeuratObject

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9082
-Date: 2023-03-28
+Version: 4.9.9.9083
+Date: 2023-04-08
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Paul', family = 'Hoffman', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9081
+Version: 4.9.9.9082
 Date: 2023-03-28
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -279,7 +279,13 @@ setClass(
   # Filter based on min.features
   if (min.features > 0) {
     for (layer in names(x = counts)) {
-      cells.use <- which(x = csum(counts[[layer]] > 0) >= min.features)
+      if (inherits(x = counts[[layer]], what = "IterableMatrix")){
+        col_stat <- BPCells::matrix_stats(matrix = counts[[layer]], 
+                                          col_stats = 'nonzero')$col_stats
+        cells.use <- which(x = col_stat >= min.features)
+      } else {
+        cells.use <- which(x = csum(counts[[layer]] > 0) >= min.features)
+      }
       counts[[layer]] <- if (cdim == 1L) {
         counts[[layer]][cells.use, ]
       } else {
@@ -291,7 +297,13 @@ setClass(
   # Filter based on min.cells
   if (min.cells > 0) {
     for (layer in names(x = counts)) {
-      features.use <- which(x = fsum(counts[[layer]] > 0) >= min.cells)
+      if (inherits(x = counts[[layer]], what = "IterableMatrix")){
+        row_stat <- BPCells::matrix_stats(matrix = counts[[layer]], 
+                                          row_stats = 'nonzero')$row_stats
+        features.use <- which(x = row_stat >= min.cells)
+      } else {
+        features.use <- which(x = fsum(counts[[layer]] > 0) >= min.cells)
+      }
       counts[[layer]] <- if (fdim == 1L) {
         counts[[layer]][features.use, ]
       } else {

--- a/R/graph.R
+++ b/R/graph.R
@@ -186,6 +186,29 @@ setValidity(
   }
 )
 
+
+#' @describeIn Graph-methods Overview of a \code{Graph} object
+#'
+#' @return \code{show}: Prints summary to \code{\link[base]{stdout}} and
+#' invisibly returns \code{NULL}
+#'
+#' @importFrom methods show
+#'
+#' @export
+#'
+setMethod(
+  f = 'show',
+  signature = 'Graph',
+  definition = function(object) {
+    cat(
+      "A Graph object containing ",
+      nrow(x = object),
+      "cells"
+    )
+  }
+)
+
+
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 # Internal
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2504,7 +2504,7 @@ RenameCells.Seurat <- function(
   for (i in Neighbors(object = object)) {
     slot(object = object, name = "neighbors")[[i]] <- RenameCells(
       object = object[[i]],
-      old.names = old.names,
+      old.names = Cells(x = object[[i]]),
       new.names = new.cell.names[Cells(x = object[[i]])]
     )
   }

--- a/man/SeuratObject-package.Rd
+++ b/man/SeuratObject-package.Rd
@@ -6,7 +6,7 @@
 \alias{SeuratObject-package}
 \title{SeuratObject: Data Structures for Single Cell Data}
 \description{
-Defines S4 classes for single-cell genomic data and associated information, such as dimensionality reduction embeddings, nearest-neighbor graphs, and spatially-resolved coordinates. Provides data access methods and R-native hooks to ensure the Seurat object is familiar to other R users. See Satija R, Farrell J, Gennert D, et al (2015) \doi{10.1038/nbt.3192}, Macosko E, Basu A, Satija R, et al (2015) \doi{10.1016/j.cell.2015.05.002}, and Stuart T, Butler A, et al (2019) \doi{10.1016/j.cell.2019.05.031} for more details.
+Defines S4 classes for single-cell genomic data and associated information, such as dimensionality reduction embeddings, nearest-neighbor graphs, and spatially-resolved coordinates. Provides data access methods and R-native hooks to ensure the Seurat object is familiar to other R users. See Satija R, Farrell J, Gennert D, et al (2015) \doi{10.1038/nbt.3192}, Macosko E, Basu A, Satija R, et al (2015) \doi{10.1016/j.cell.2015.05.002}, and Stuart T, Butler A, et al (2019) \doi{10.1016/j.cell.2019.05.031}, Hao Y, Hao S, et al (2021) \doi{10.1016/j.cell.2021.04.048} and Hao Y, et al (2023) \doi{10.1101/2022.02.24.481684} for more details.
 }
 \seealso{
 Useful links:
@@ -23,6 +23,9 @@ Useful links:
 Authors:
 \itemize{
   \item Rahul Satija \email{rsatija@nygenome.org} (\href{https://orcid.org/0000-0001-9448-8833}{ORCID})
+  \item Yuhan Hao \email{yhao@nygenome.org} (\href{https://orcid.org/0000-0002-1810-0822}{ORCID})
+  \item Austin Hartman \email{ahartman@nygenome.org} (\href{https://orcid.org/0000-0001-7278-1852}{ORCID})
+  \item Gesmira Molla \email{gmolla@nygenome.org} (\href{https://orcid.org/0000-0002-8628-5056}{ORCID})
   \item Andrew Butler \email{abutler@nygenome.org} (\href{https://orcid.org/0000-0003-3608-0463}{ORCID})
   \item Tim Stuart \email{tstuart@nygenome.org} (\href{https://orcid.org/0000-0002-3044-0897}{ORCID})
 }
@@ -33,7 +36,6 @@ Other contributors:
   \item Shiwei Zheng \email{szheng@nygenome.org} (\href{https://orcid.org/0000-0001-6682-6743}{ORCID}) [contributor]
   \item Christoph Hafemeister \email{chafemeister@nygenome.org} (\href{https://orcid.org/0000-0001-6365-8254}{ORCID}) [contributor]
   \item Patrick Roelli \email{proelli@nygenome.org} [contributor]
-  \item Yuhan Hao \email{yhao@nygenome.org} (\href{https://orcid.org/0000-0002-1810-0822}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
When providing a list of IterableMatrix, allow filtering so the following code works: 
`merged.object <- CreateSeuratObject(counts = data.list,min.cells = 3,min.features = 500)`