### PR TITLE
Modifying saveRDS for BPCells + other v5 updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9085
-Date: 2023-04-17
+Version: 4.9.9.9086
+Date: 2023-06-27
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Paul', family = 'Hoffman', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.9.9.9084
+Version: 4.9.9.9085
 Date: 2023-04-17
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),

--- a/R/assay.R
+++ b/R/assay.R
@@ -523,8 +523,14 @@ LayerData.Assay <- function(
   layer = NULL,
   cells = NULL,
   features = NULL,
+  slot = deprecated()
   ...
 ) {
+  if (is_present(arg = slot)) {
+    deprecate_stop(when = "5.0.0", 
+                   what = "LayerData(slot = )", 
+                   with = "LayerData(layer = )")
+  }
   # Figure out which matrix we're pulling
   layer <- layer[1L] %||% DefaultLayer(object = object)
   # layer <- match.arg(
@@ -532,7 +538,7 @@ LayerData.Assay <- function(
   #   choices = Layers(object = object, search = FALSE)
   # )
   # Handle empty layers
-  if (IsMatrixEmpty(x = slot(object = object, name = layer))) {
+  if (IsMatrixEmpty(x = methods::slot(object = object, name = layer))) {
     msg <- paste("Layer", sQuote(x = layer), "is empty")
     opt <- getOption(
       x = 'Seurat.object.assay.v3.missing_layer',
@@ -578,7 +584,7 @@ LayerData.Assay <- function(
     multiple = TRUE
   )
   # Pull the matrix for the cells/features requested
-  return(slot(object = object, name = layer)[features, cells])
+  return(methods::slot(object = object, name = layer)[features, cells])
 }
 
 #' @rdname Layers

--- a/R/assay.R
+++ b/R/assay.R
@@ -523,7 +523,7 @@ LayerData.Assay <- function(
   layer = NULL,
   cells = NULL,
   features = NULL,
-  slot = deprecated()
+  slot = deprecated(),
   ...
 ) {
   if (is_present(arg = slot)) {

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -313,6 +313,7 @@ setClass(
     }
   }
   features.all <- Reduce(f = union, x = features)
+  cells.all <- make.unique(names = unlist(x = cells))
   calcN_option <- getOption(
     x = 'Seurat.object.assay.calcn',
     default =  Seurat.options$Seurat.object.assay.calcn
@@ -323,7 +324,7 @@ setClass(
     layers = list(),
     default = 0L,
     features = LogMap(y = features.all),
-    cells = LogMap(y = Reduce(f = union, x = cells)),
+    cells = LogMap(y = cells.all),
     meta.data = EmptyDF(n = length(x = features.all)),
     misc = list(calcN = calcN_option %||% TRUE),
     ...

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1091,8 +1091,14 @@ LayerData.StdAssay <- function(
   cells = NULL,
   features = NULL,
   fast = FALSE,
+  slot = deprecated(),
   ...
 ) {
+  if (is_present(arg = slot)) {
+    deprecate_stop(when = "5.0.0", 
+                   what = "LayerData(slot = )", 
+                   with = "LayerData(layer = )")
+  }
   # Figure out the layer we're pulling
   layer_name <- layer[1L] %||% DefaultLayer(object = object)[1L]
   layer <- Layers(object = object, search = layer)
@@ -1153,9 +1159,9 @@ LayerData.StdAssay <- function(
   dnames[[1L]] <- dnames[[1L]][features]
   # Pull the layer data
   ldat <- if (.MARGIN(x = object) == 1L) {
-    slot(object = object, name = 'layers')[[layer]][features, cells, drop = FALSE]
+    methods::slot(object = object, name = 'layers')[[layer]][features, cells, drop = FALSE]
   } else {
-    slot(object = object, name = 'layers')[[layer]][cells, features, drop = FALSE]
+    methods::slot(object = object, name = 'layers')[[layer]][cells, features, drop = FALSE]
   }
   # Add dimnames and transpose if requested
   ldat <- if (isTRUE(x = fast)) {

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -978,12 +978,15 @@ SaveSeuratBP <- function(
               call. = FALSE, immediate. = TRUE)
       ldat <- LayerData(object[[assay]], layer = layer)
       matrices <- BPCells:::all_matrix_inputs(ldat)
-      for (i in seq_along(matrices)) {
-        if (inherits(x = matrices[[i]], what = "MatrixDir")) {
-          matrices[[i]]@dir <- df[df$layer == layer, ]$path[i]
+      matrix.dirs <- which(sapply(matrices, function(x) inherits(x, "MatrixDir")))
+      if (length(matrix.dirs) == nrow(df[df$layer == layer, ])){
+        for (i in 1:length(matrix.dirs)) {
+          matrices[[matrix.dirs[i]]]@dir <- df[df$layer == layer, ]$path[i]
         }
         BPCells:::all_matrix_inputs(ldat) <- matrices
         LayerData(object[[assay]], layer = layer) <- ldat
+      } else {
+        stop("Directories to replace is not equal to length of directories")
       }
     }
     p()

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -985,7 +985,7 @@ SaveSeuratBP <- function(
         matrix <- matrix@matrix_list[[df[i,]$matrix_num]]@matrix
       }
       matrix@dir <- path
-      ldat@matrix <- matrix
+      ldat@matrix@matrix_list[[df[i,]$matrix_num]]@matrix <- matrix
       LayerData(object[[df[i,]$assay]], layer = df[i,]$layer) <- ldat
     }
     p()

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2267,7 +2267,18 @@ Keys.Seurat <- Key.Seurat
 #' @method LayerData Seurat
 #' @export
 #'
-LayerData.Seurat <- function(object, layer = NULL, assay = NULL, ...) {
+LayerData.Seurat <- function(
+    object, 
+    layer = NULL, 
+    assay = NULL, 
+    slot = deprecated(), 
+    ...
+) {
+  if (is_present(arg = slot)) {
+    deprecate_stop(when = "5.0.0", 
+                   what = "LayerData(slot = )", 
+                   with = "LayerData(layer = )")
+  }
   assay <- assay %||% DefaultAssay(object = object)
   assay <- arg_match(arg = assay, values = Assays(object = object))
   return(LayerData(object = object[[assay]], layer = layer, ...))

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -980,7 +980,7 @@ SaveSeuratBP <- function(
       layer <- i
       ldat <- LayerData(object[[assay]],layer = layer)
       matrices <- BPCells:::all_matrix_inputs(ldat)
-      df_layer <- df[df$layer == layer]
+      df_layer <- df[df$layer == layer, ]
       paths <- df_layer$path
       # Ensure num of rows is equal to num of matrix inputs
       if (nrow(df_layer) == length(matrices)){

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -917,10 +917,11 @@ SaveSeuratBP <- function(
           return(NULL)
         }
         return(data.frame(
-          layer = lyr,
+          layer = rep(lyr, length(path)),
+          matrix_num = seq_len(length(path)),
           path = path,
-          class = paste(class(x = ldat), collapse = ','),
-          pkg = .ClassPkg(object = ldat)
+          class = rep(paste(class(x = ldat), collapse = ','), length(path)),
+          pkg = rep(.ClassPkg(object = ldat), length(path))
         ))
       }
     )
@@ -979,7 +980,12 @@ SaveSeuratBP <- function(
       ldat <- LayerData(object[[df[i,]$assay]],
                         layer = df[i,]$layer)
       path <- df[i,]$path
-      ldat@matrix@dir <- path
+      matrix <- slot(ldat, "matrix")
+      if ("matrix_list" %in% slotNames(matrix)){
+        matrix <- matrix@matrix_list[[df[i,]$matrix_num]]@matrix
+      }
+      matrix@dir <- path
+      ldat@matrix <- matrix
       LayerData(object[[df[i,]$assay]], layer = df[i,]$layer) <- ldat
     }
     p()

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -973,26 +973,17 @@ SaveSeuratBP <- function(
       ))
     }
     df$assay <- assay
-    for (i in unique(df$layer)){
-      warning("Changing path in object to point to new BPCells directory location",
-              call. = FALSE,
-              immediate. = TRUE)
-      layer <- i
-      ldat <- LayerData(object[[assay]],layer = layer)
+    for (layer in unique(df$layer)) {
+      warning("Changing path in object to point to new BPCells directory location", 
+              call. = FALSE, immediate. = TRUE)
+      ldat <- LayerData(object[[assay]], layer = layer)
       matrices <- BPCells:::all_matrix_inputs(ldat)
-      df_layer <- df[df$layer == layer, ]
-      paths <- df_layer$path
-      # Ensure num of rows is equal to num of matrix inputs
-      if (nrow(df_layer) == length(matrices)){
-        for (i in seq_along(matrices)){
-          if (inherits(x = matrices[[i]], what = "MatrixDir")) {
-            matrices[[i]]@dir <- paths[i]
-          }
+      for (i in seq_along(matrices)) {
+        if (inherits(x = matrices[[i]], what = "MatrixDir")) {
+          matrices[[i]]@dir <- df[df$layer == layer, ]$path[i]
         }
         BPCells:::all_matrix_inputs(ldat) <- matrices
         LayerData(object[[assay]], layer = layer) <- ldat
-      } else {
-        stop("Number of BPCells matrices to replace is not equal to number of matrices")
       }
     }
     p()

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -836,7 +836,6 @@ SaveSeuratRds <- function(
 #' @param relative Save relative paths instead of absolute ones. This is recommended
 #' if sharing the object folder
 #' @inheritDotParams base::saveRDS
-#' @importFrom dplyr %>% 
 #'
 #' @return Invisibly returns \code{file}
 #'
@@ -947,7 +946,7 @@ SaveSeuratBP <- function(
               path = pth,
               new_path = destdir
             )), error = function(e) {
-              warning("Error: ", e)
+              warning("Error: ", e, call. = FALSE)
               # Return original path if can't locate new path
               return(pth)
             }
@@ -979,10 +978,10 @@ SaveSeuratBP <- function(
               call. = FALSE,
               immediate. = TRUE)
       layer <- i
-      df_layer <- df %>% filter(layer == layer)
       ldat <- LayerData(object[[assay]],layer = layer)
-      paths <- df_layer$path
       matrices <- BPCells:::all_matrix_inputs(ldat)
+      df_layer <- df[df$layer == layer]
+      paths <- df_layer$path
       # Ensure num of rows is equal to num of matrix inputs
       if (nrow(df_layer) == length(matrices)){
         for (i in seq_along(matrices)){

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -985,7 +985,9 @@ SaveSeuratBP <- function(
       # Ensure num of rows is equal to num of matrix inputs
       if (nrow(df_layer) == length(matrices)){
         for (i in seq_along(matrices)){
-          matrices[[i]]@dir <- paths[i]
+          if (inherits(x = matrices[[i]], what = "MatrixDir")) {
+            matrices[[i]]@dir <- paths[i]
+          }
         }
         BPCells:::all_matrix_inputs(ldat) <- matrices
         LayerData(object[[assay]], layer = layer) <- ldat

--- a/R/utils.R
+++ b/R/utils.R
@@ -1446,7 +1446,20 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
   path <- tryCatch(expr = normalizePath(path = x@matrix@dir),
                    error = function(...) NULL)
   if (is.null(x = path)) {
-    warn(message = "The matrix provided does not exist on-disk")
+    if (inherits(x@matrix, "10xMatrixH5")){
+      warning("The on-disk matrix is an h5 file and will not be moved ",
+           "to the destination directory. It will remain at: ", x@matrix@path,
+           ". If you would like to save the matrix in BPCells format, use", 
+           "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
+    } else if (inherits(x@matrix, "AnnDataMatrixH5")){
+      warning("The on-disk matrix is an h5ad file and will not be moved ",
+           "to the destination directory. It will remain at: ", x@matrix@path,
+           ". If you would like to save the matrix in BPCells format, use", 
+           "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
+    }
+    else {
+      warn(message = "The matrix provided does not exist on-disk")
+    }
   }
   return(path)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1459,10 +1459,7 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
               "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
       path = NULL
     } else {
-      path <- tryCatch(expr = normalizePath(path = matrix@dir),
-                       error = function(...) {
-                         warning(message = "The matrix provided  does not exist on-disk")
-                         return(NULL)})
+      path <- normalizePath(path = matrix@dir)
     }
     return(path)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1446,7 +1446,9 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
   matrix <- slot(x, "matrix")
   matrices <- BPCells:::all_matrix_inputs(matrix)
   return_dir_path <- function(matrix){
-    if (inherits(matrix, "10xMatrixH5")){
+    if (inherits(matrix, "MatrixDir")) {
+      path <- normalizePath(path = matrix@dir)
+    } else if (inherits(matrix, "10xMatrixH5")){
       warning("The on-disk matrix is an h5 file and will not be moved ",
               "to the destination directory. It will remain at: '", matrix@path,
               "'. If you would like to save the matrix in BPCells format, use", 
@@ -1459,7 +1461,7 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
               "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
       path = NULL
     } else {
-      path <- normalizePath(path = matrix@dir)
+      path = NULL
     }
     return(path)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1451,14 +1451,14 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
     } else if (inherits(matrix, "10xMatrixH5")){
       warning("The on-disk matrix is an h5 file and will not be moved ",
               "to the destination directory. It will remain at: '", matrix@path,
-              "'. If you would like to save the matrix in BPCells format, use", 
-              "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
+              "'. If you would like to save the matrix in BPCells format, use ", 
+              "'write_matrix_dir(mat = data, dir = '/path')'.", call. = FALSE)
       path = NULL 
     } else if (inherits(matrix, "AnnDataMatrixH5")){
       warning("The on-disk matrix is an h5ad file and will not be moved ",
               "to the destination directory. It will remain at: '", matrix@path,
-              "'. If you would like to save the matrix in BPCells format, use", 
-              "'write_matrix_dir(mat = data, dir = '/path').", call. = FALSE)
+              "'. If you would like to save the matrix in BPCells format, use ", 
+              "'write_matrix_dir(mat = data, dir = '/path')'.", call. = FALSE)
       path = NULL
     } else {
       path = NULL


### PR DESCRIPTION
1. Adding a warning if someone hasn't written out the BPCells matrix and it's instead an h5/h5ad file on disk. Pointed out in [this issue](https://github.com/satijalab/seurat/issues/7165). 
```
> h5ad_data <- open_matrix_anndata_hdf5("/brahms/mollag/seurat_v5/h5ad_files/jin_pbmc.h5ad")
> h5ad.obj <- CreateSeuratObject(h5ad_data)
Counts matrix provided is not sparse. Creating V5 assay in Seurat Object.
> saveRDS(object = h5ad.obj, file = "h5ad.rds", destdir = "/brahms/mollag/seurat_v5/example/")
Warning message:
The on-disk matrix is an h5ad file and will not be moved to the destination directory. It will remain at: '/brahms/mollag/seurat_v5/h5ad_files/jin_pbmc.h5ad'. If you would like to save the matrix in BPCells format, use'write_matrix_dir(mat = data, dir = '/path'). 
```


2. In the case where someone joins layers which each had their own BP matrices, moves each matrix within each layer individually instead of not being able to find BP matrix. Pointed out in [this issue](https://github.com/satijalab/seurat/issues/7128). 
This is due to the change in structure when there's a list of matrices: 

<img width="754" alt="Screen Shot 2023-05-23 at 11 16 41 AM" src="https://github.com/mojaveazure/seurat-object/assets/59940281/ced9ab41-62ec-4f4a-96bf-1bb27f1d0152">


```
> pbmc <- LoadData("pbmc3k")
> pbmc$random <- sample(c("a", "b"), size = nrow(pbmc@meta.data), replace = T)
> pbmc <- split(pbmc, f = pbmc$random)

# Write out layers
> write_matrix_dir(pbmc[["RNA"]]$counts.a, dir = "/brahms/mollag/seurat_v5/example/pbmc_a_counts")
> write_matrix_dir(pbmc[["RNA"]]$counts.b, dir = "/brahms/mollag/seurat_v5/example/pbmc_b_counts")

> pbmc[["RNA"]]$counts.a <- open_matrix_dir("/brahms/mollag/seurat_v5/example/pbmc_a_counts")
> pbmc[["RNA"]]$counts.b <- open_matrix_dir("/brahms/mollag/seurat_v5/example/pbmc_b_counts")

# Join Layers
> pbmc.joined <- JoinLayers(pbmc)

# Save, moving both matrices to new location 
> saveRDS(object = pbmc.joined, file = "pbmc_joined.rds", destdir = "/brahms/mollag/seurat_v5/example/pbmc/")
Warning: Changing path in object to point to new BPCells directory location
Warning: Changing path in object to point to new BPCells directory location
```

3. Fix bug where duplicate barcodes were removed from total cell count instead of being made unique

4. Deprecating slot argument in LayerData()

```
> LayerData(pbmc, slot = "counts")
Error:
! The `slot` argument of `LayerData()` was deprecated in SeuratObject 5.0.0 and is now
  defunct.
ℹ Please use the `layer` argument instead.
Run `rlang::last_trace()` to see where the error occurred.
```