### PR TITLE
Feat/double bracket error msg

### DIFF
--- a/R/seurat.R
+++ b/R/seurat.R
@@ -974,7 +974,7 @@ SaveSeuratBP <- function(
     }
     df$assay <- assay
     for (layer in unique(df$layer)) {
-      warning("Changing path in object to point to new BPCells directory location", 
+      warning("Changing path in object to point to new BPCells directory location",
               call. = FALSE, immediate. = TRUE)
       ldat <- LayerData(object[[assay]], layer = layer)
       matrices <- BPCells:::all_matrix_inputs(ldat)
@@ -2271,15 +2271,15 @@ Keys.Seurat <- Key.Seurat
 #' @export
 #'
 LayerData.Seurat <- function(
-    object, 
-    layer = NULL, 
-    assay = NULL, 
-    slot = deprecated(), 
+    object,
+    layer = NULL,
+    assay = NULL,
+    slot = deprecated(),
     ...
 ) {
   if (is_present(arg = slot)) {
-    deprecate_stop(when = "5.0.0", 
-                   what = "LayerData(slot = )", 
+    deprecate_stop(when = "5.0.0",
+                   what = "LayerData(slot = )",
                    with = "LayerData(layer = )")
   }
   assay <- assay %||% DefaultAssay(object = object)
@@ -3122,19 +3122,21 @@ Version.Seurat <- function(object, ...) {
     NULL
   }
   # Pull cell-level meta data
-  
   if (is.null(x = slot.use)) {
     i <- tryCatch(
       expr = arg_match(arg = i, values = meta.cols, multiple = TRUE),
       error = function(e) {
-        check.colnames <- sapply(i, function(x) x %in% meta.cols)
         #error message that indicates which colnames not found
-        stop(paste0( paste0("'", names(check.colnames[!check.colnames]), "'",
-                            collapse = ", "),
-                     " not found in Seurat object", "\n", e$body), 
-               call. = FALSE)
+        abort(
+          message = paste(
+            paste(sQuote(x = setdiff(x = i, y = meta.cols)), collapse = ', '),
+            "not found in this Seurat object\n",
+            e$body
+          ),
+          call = rlang::caller_env(n = 4L)
+        )
       }
-      )
+    )
     # Pull the cell-level meta data
     data.return <- md[, i, drop = FALSE, ...]
     # If requested, remove NAs

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1660,11 +1660,6 @@ DefaultFOV.Seurat <- function(object, assay = NULL, ...) {
 #' Embeddings(object = pbmc_small, reduction = "pca")[1:5, 1:5]
 #'
 Embeddings.Seurat <- function(object, reduction = 'pca', ...) {
-  #check if DimReduc is present
-  
-  if (!(reduction %in% names(slot(object = object, name = "reductions")))) {
-    stop(paste0("Cannot find '", reduction, "' in this Seurat object"))
-  }
   return(Embeddings(object = object[[reduction]], ...))
 }
 
@@ -3127,9 +3122,19 @@ Version.Seurat <- function(object, ...) {
     NULL
   }
   # Pull cell-level meta data
+  
   if (is.null(x = slot.use)) {
-    # Identify the cell-level meta data to use
-    i <- arg_match(arg = i, values = meta.cols, multiple = TRUE)
+    i <- tryCatch(
+      expr = arg_match(arg = i, values = meta.cols, multiple = TRUE),
+      error = function(e) {
+        check.colnames <- sapply(i, function(x) x %in% meta.cols)
+        stop(  paste0( paste0("'", names(check.colnames[!check.colnames]), "'", collapse = ", and/or "),
+                       " not found in Seurat object", "\n", e$body), 
+               call. = FALSE)
+      }
+      )
+    #original
+    #i <- arg_match(arg = i, values = meta.cols, multiple = TRUE)
     # Pull the cell-level meta data
     data.return <- md[, i, drop = FALSE, ...]
     # If requested, remove NAs

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -1660,6 +1660,11 @@ DefaultFOV.Seurat <- function(object, assay = NULL, ...) {
 #' Embeddings(object = pbmc_small, reduction = "pca")[1:5, 1:5]
 #'
 Embeddings.Seurat <- function(object, reduction = 'pca', ...) {
+  #check if DimReduc is present
+  
+  if (!(reduction %in% names(slot(object = object, name = "reductions")))) {
+    stop(paste0("Cannot find '", reduction, "' in this Seurat object"))
+  }
   return(Embeddings(object = object[[reduction]], ...))
 }
 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -3128,13 +3128,13 @@ Version.Seurat <- function(object, ...) {
       expr = arg_match(arg = i, values = meta.cols, multiple = TRUE),
       error = function(e) {
         check.colnames <- sapply(i, function(x) x %in% meta.cols)
-        stop(  paste0( paste0("'", names(check.colnames[!check.colnames]), "'", collapse = ", and/or "),
-                       " not found in Seurat object", "\n", e$body), 
+        #error message that indicates which colnames not found
+        stop(paste0( paste0("'", names(check.colnames[!check.colnames]), "'",
+                            collapse = ", "),
+                     " not found in Seurat object", "\n", e$body), 
                call. = FALSE)
       }
       )
-    #original
-    #i <- arg_match(arg = i, values = meta.cols, multiple = TRUE)
     # Pull the cell-level meta data
     data.return <- md[, i, drop = FALSE, ...]
     # If requested, remove NAs


### PR DESCRIPTION
Update to error message when accessing meta-data or DimReducs with [[. Previously when trying to access a DimReduc that is not present in object, the error message would print out all meta-data, which could be confusing. 

Example below.
```
options(Seurat.object.assay.version = 'v5')
pbmc3k <- LoadData("pbmc3k")
pbmc3k <- NormalizeData(pbmc3k)
pbmc3k <- FindVariableFeatures(pbmc3k)
pbmc3k <- ScaleData(pbmc3k)
pbmc3k <- RunPCA(pbmc3k)

pbmc3k[['pca']] # correctly returns pca
pbmc3k[[c('pca', 'umap')]] # umap is not present, so returns error
# previously this error would print all meta data columns, which was confusing
pbmc3k[['umap']] # also returns error
pbmc3k[[c("blah", "orig.ident", "seurat_annotation", "blah2")]]
# identifies which meta data features are not present
pbmc3k[["nCounts_RNA"]] # maintains suggestions
```