### PR TITLE
Remove `rgeos` from suggests and add `sf`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
 Version: 4.1.3.9003
-Date: 2023-06-07
+Date: 2023-07-21
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 4.1.3.9002
-Date: 2023-03-08
+Version: 4.1.3.9003
+Date: 2023-06-07
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
@@ -29,7 +29,7 @@ BugReports:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends:
     R (>= 4.0.0),
     sp (>= 1.5.0)
@@ -48,7 +48,7 @@ Imports:
     utils
 Suggests:
     ggplot2,
-    rgeos,
+    sf,
     testthat
 Collate:
     'RcppExports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # Unreleased
 ## Changes
 - Fixes for `CellsByIdentities` (#80)
+- Remove {rgeos} from Suggests and replace with {sf} due to {rgeos} package retirement
 
 # SeuratObject 4.1.3
 ## Changes
-- Move {rgeos} to Suggests; segmentation simplification now requires {regos} to be installed manually
+- Move {rgeos} to Suggests; segmentation simplification now requires {rgeos} to be installed manually
 - Move {sp} to Depends
 
 ## Added

--- a/R/generics.R
+++ b/R/generics.R
@@ -1064,7 +1064,6 @@ SetIdent <- function(object, ...) {
 
 #' Simplify Geometry
 #'
-#' @inheritParams rgeos::gSimplify
 #' @param coords ...
 #'
 #' @return ...

--- a/R/utils.R
+++ b/R/utils.R
@@ -708,7 +708,7 @@ S4ToList.list <- function(object) {
   return(object)
 }
 
-#' Check the existence of a package
+#' Simplify segmentations by reducing the number of vertices
 #'
 #' @param coords A `Segmentation` object
 #' @param tol Numerical tolerance value to be used by the Douglas-Peuker algorithm

--- a/R/utils.R
+++ b/R/utils.R
@@ -708,35 +708,43 @@ S4ToList.list <- function(object) {
   return(object)
 }
 
+#' Check the existence of a package
+#'
+#' @param coords A `Segmentation` object
+#' @param tol Numerical tolerance value to be used by the Douglas-Peuker algorithm
+#' @param topologyPreserve Logical determining if the algorithm should attempt to preserve the topology of the original geometry
+#'
+#' @return A `Segmentation` object with simplified segmentation vertices
+#' 
 #' @rdname Simplify
 #' @method Simplify Spatial
 #' @export
 #'
 Simplify.Spatial <- function(coords, tol, topologyPreserve = TRUE) {
-  if (!PackageCheck('rgeos', error = FALSE)) {
-    stop("'Simplify' requires rgeos to be installed", call. = FALSE)
+  if (!PackageCheck("sf", error = FALSE)) {
+    stop("'Simplify' requires sf to be installed", call. = FALSE)
   }
   class.orig <- class(x = coords)
+  coords.orig <- coords
   dest <- ifelse(
-    test = grepl(pattern = '^Spatial', x = class.orig),
+    test = grepl(pattern = "^Spatial", x = class.orig), 
     yes = class.orig,
-    no = grep(
-      pattern = '^Spatial',
-      x = .Contains(object = coords),
-      value = TRUE
-    )[1L]
-  )
-  coords <- rgeos::gSimplify(
-    spgeom = as(object = coords, Class = dest),
-    tol = as.numeric(x = tol),
-    topologyPreserve = isTRUE(x = topologyPreserve)
-  )
-  coords <- tryCatch(
-    expr = as(object = coords, Class = class.orig),
-    error = function(...) {
-      return(coords)
-    }
-  )
+    no = grep(pattern = "^Spatial", x = .Contains(object = coords), value = TRUE)[1L])
+  x <- sf::st_as_sfc(as(object = coords, Class = dest))
+  coords <- sf::st_simplify(
+    x = x,
+    dTolerance = as.numeric(x = tol),
+    preserveTopology = isTRUE(x = topologyPreserve))
+  coords <- sf::st_sf(geometry = coords)
+  coords <- as(coords, Class = "Spatial")
+  coords <- as(coords, Class = "Segmentation")
+  slot(object = coords, name = "polygons") <- mapply(
+    FUN = function(x, y) {
+      slot(object = x, name = "ID") <- y
+      return(x)
+    },
+    slot(object = coords, name = "polygons"),
+    Cells(coords.orig))
   return(coords)
 }
 

--- a/man/Simplify.Rd
+++ b/man/Simplify.Rd
@@ -24,5 +24,5 @@ A `Segmentation` object with simplified segmentation vertices
 \description{
 Simplify Geometry
 
-Check the existence of a package
+Simplify segmentations by reducing the number of vertices
 }

--- a/man/Simplify.Rd
+++ b/man/Simplify.Rd
@@ -10,7 +10,7 @@ Simplify(coords, tol, topologyPreserve = TRUE)
 \method{Simplify}{Spatial}(coords, tol, topologyPreserve = TRUE)
 }
 \arguments{
-\item{coords}{...}
+\item{coords}{A `Segmentation` object}
 
 \item{tol}{Numerical tolerance value to be used by the Douglas-Peuker algorithm}
 
@@ -18,7 +18,11 @@ Simplify(coords, tol, topologyPreserve = TRUE)
 }
 \value{
 ...
+
+A `Segmentation` object with simplified segmentation vertices
 }
 \description{
 Simplify Geometry
+
+Check the existence of a package
 }


### PR DESCRIPTION
`maptools`, `rgdal`, and `rgeos` are being pulled from CRAN in October 2023 and we use `rgeos` in the segmentation simplification function. This PR removes the `rgeos` with an equivalent `sf` function. Per R warnings, `sp`, which makes heavy use of `rgeos` under the hood, will also use `sf` instead.