### PR TITLE
Warnings and BPCells exported function 

### DIFF
--- a/R/assay.R
+++ b/R/assay.R
@@ -621,7 +621,11 @@ LayerData.Assay <- function(
   )
   # Check the class of the matrix
   if (!inherits(x = value, what = c('matrix', 'dgCMatrix'))) {
-    abort(message = "'value' must be a 'matrix' or 'dgCMatrix'")
+    if (inherits(x = value, what = "IterableMatrix")) {
+      abort(message = "Can't set BPCells matrix to layer in v3 Assays.")
+    } else {
+      abort(message = "'value' must be a 'matrix' or 'dgCMatrix'")
+    }
   }
   if (!IsMatrixEmpty(x = value)) {
     vnames <- dimnames(x = value)

--- a/R/assay.R
+++ b/R/assay.R
@@ -621,11 +621,10 @@ LayerData.Assay <- function(
   )
   # Check the class of the matrix
   if (!inherits(x = value, what = c('matrix', 'dgCMatrix'))) {
-    if (inherits(x = value, what = "IterableMatrix")) {
-      abort(message = "Can't set BPCells matrix to layer in v3 Assays.")
-    } else {
-      abort(message = "'value' must be a 'matrix' or 'dgCMatrix'")
-    }
+   abort(message = paste(
+     "'value' must be a 'matrix' or 'dgCMatrix' in v3 Assays, not a", 
+     sQuote(x = class(x = value)[1L])
+   ))
   }
   if (!IsMatrixEmpty(x = value)) {
     vnames <- dimnames(x = value)

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -977,13 +977,13 @@ SaveSeuratBP <- function(
       warning("Changing path in object to point to new BPCells directory location",
               call. = FALSE, immediate. = TRUE)
       ldat <- LayerData(object[[assay]], layer = layer)
-      matrices <- BPCells:::all_matrix_inputs(ldat)
+      matrices <- BPCells::all_matrix_inputs(ldat)
       matrix.dirs <- which(sapply(matrices, function(x) inherits(x, "MatrixDir")))
       if (length(matrix.dirs) == nrow(df[df$layer == layer, ])){
         for (i in 1:length(matrix.dirs)) {
           matrices[[matrix.dirs[i]]]@dir <- df[df$layer == layer, ]$path[i]
         }
-        BPCells:::all_matrix_inputs(ldat) <- matrices
+        BPCells::all_matrix_inputs(ldat) <- matrices
         LayerData(object[[assay]], layer = layer) <- ldat
       } else {
         stop("Directories to replace is not equal to length of directories")

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -4285,10 +4285,8 @@ setMethod(
         )
       }
       if (!all(dim(x = value) == dim(x = x[[i]]))) {
-        warning(
-          "Different cells and/or features from existing assay ", i,
-          call. = FALSE,
-          immediate. = TRUE,
+        warn(
+          message = paste0("Different cells and/or features from existing assay ", i),
           class = 'dimWarning'
         )
       }

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -4288,7 +4288,8 @@ setMethod(
         warning(
           "Different cells and/or features from existing assay ", i,
           call. = FALSE,
-          immediate. = TRUE
+          immediate. = TRUE,
+          class = 'dimWarning'
         )
       }
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1444,7 +1444,7 @@ RowMergeSparseMatrices <- function(mat1, mat2) {
 .FilePath.IterableMatrix <- function(x){
   check_installed(pkg = "BPCells", reason = "for working with BPCells")
   matrix <- slot(x, "matrix")
-  matrices <- BPCells:::all_matrix_inputs(matrix)
+  matrices <- BPCells::all_matrix_inputs(matrix)
   return_dir_path <- function(matrix){
     if (inherits(matrix, "MatrixDir")) {
       path <- normalizePath(path = matrix@dir)


### PR DESCRIPTION
- Added a more informative warning if users try to set a BPCells matrix to slot in v3 assay
- Added classed warning so can be suppressed in Seurat
- updated BPCells::all_matrix_inputs as it is exported now 