### PR TITLE
Add check for newer ABIs

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 #' @importFrom sp bbox over
 #' @importFrom Rcpp evalCpp
-#' @importFrom utils head tail
+#' @importFrom utils head tail packageVersion
 #' @importFrom methods new setClass setClassUnion setMethod setOldClass
 #' setValidity slot slot<- validObject
 #' @importClassesFrom Matrix dgCMatrix
@@ -22,6 +22,16 @@ Seurat.options <- list(
   Seurat.input.sparse_ratio = 0.4,
   Seurat.coords.short_range = 'max',
   progressr.clear = FALSE
+)
+
+
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+# Built With
+#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+.BuiltWith <- c(
+  R = format(x = getRversion()),
+  Matrix = format(x = packageVersion(pkg = "Matrix"))
 )
 
 #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -464,6 +474,29 @@ NameIndex <- function(x, names, MARGIN) {
   toset <- setdiff(x = names(x = Seurat.options), y = names(x = options()))
   if (length(x = toset)) {
     options(Seurat.options[toset])
+  }
+  for (i in names(x = .BuiltWith)) {
+    current <- switch(EXPR = i, R = getRversion(), packageVersion(pkg = i))
+    if (current > .BuiltWith[i]) {
+      msg <- paste(
+        sQuote(x = pkgname),
+        "was built",
+        switch(
+          EXPR = i,
+          R = "under R",
+          paste("with package", sQuote(x = i))
+        ),
+        .BuiltWith[i],
+        "but the current version is",
+        paste0(current, ';'),
+        "it is recomended that you reinstall ",
+        sQuote(x = pkgname),
+        " as the ABI for",
+        switch(EXPR = i, R = i, sQuote(x = i)),
+        "may have changed"
+      )
+      packageStartupMessage(paste(strwrap(x = msg), collapse = '\n'))
+    }
   }
   return(invisible(x = NULL))
 }


### PR DESCRIPTION
Add check on package attachment to see if dependencies have udpated. These updates may cause runtime binary breaks in SeuratObject, but still allow SeuratObject to be loaded, so this check happens at attachment