### PR TITLE
Stop auto transposition in `.PrepLayerData2()`

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -154,7 +154,7 @@ setGeneric(
 .PrepLayerData2 <- function(
   x,
   target = NULL,
-  transpose = NULL,
+  transpose = FALSE,
   dnames = NULL,
   fmargin = 1L
 ) {


### PR DESCRIPTION
Disable auto transposition when adding new layers with `.PrepLayerData2()`; auto transposition can still be enabled with `transpose = NULL`