### PR TITLE
Split.StdAssay

### DIFF
--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2140,23 +2140,30 @@ split.StdAssay <- function(
   x,
   f,
   drop = FALSE,
-  layers = NA,
+  layers = NULL,
   ret = c('assay', 'multiassays', 'layers'),
   ...
 ) {
   ret <- ret[1L]
   ret <- match.arg(arg = ret)
+  if (is.na(layers) || is.null(layers)) {
+    layers <- c("counts", "data")
+  }
+  if (identical(layers, c("counts", "data"))) {
+    message("Splitting 'counts' and 'data' layers by default. ", 
+            "If you would like to split other layers, set in ‘layers’ argument.")
+  }
   layers <- Layers(object = x, search = layers)
-  layers.splitted <- list()
+  layers.split <- list()
   for (i in seq_along(along.with = layers)) {
     if (length(colnames(x[[layers[i]]])) != length(colnames(x))) {
-      layers.splitted[[i]] <- layers[i]
+      layers.split[[i]] <- layers[i]
     }
   }
-  layers.splitted <- unlist(x = layers.splitted)
-  if (length(x = layers.splitted) > 0) {
-   stop('Those layers are splitted already: ', paste(layers.splitted, collapse = ' '),
-        '\n', 'Please join those layers before splitting'
+  layers.split <- unlist(x = layers.split)
+  if (length(x = layers.split) > 0) {
+   stop('The selected layers are already split: ', paste(layers.split, collapse = ' '),
+        '\n', 'Please join layers before splitting.'
         )
   }
   default <- ifelse(

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2140,18 +2140,18 @@ split.StdAssay <- function(
   x,
   f,
   drop = FALSE,
-  layers = NULL,
+  layers = c("counts", "data"),
   ret = c('assay', 'multiassays', 'layers'),
   ...
 ) {
   ret <- ret[1L]
   ret <- match.arg(arg = ret)
-  if (is.na(layers) || is.null(layers)) {
-    layers <- c("counts", "data")
-  }
-  if (identical(layers, c("counts", "data"))) {
-    message("Splitting 'counts' and 'data' layers by default. ", 
-            "If you would like to split other layers, set in ‘layers’ argument.")
+  layers.to.split <- Layers(object = x, search = layers)
+  if (!identical(Layers(object = x), layers.to.split)){
+     message('Splitting "', paste(layers.to.split, collapse = ", "), 
+             '" layers. Not splitting "', 
+             paste(setdiff(Layers(object = x), layers.to.split), collapse = ", "), 
+             '". If you would like to split other layers, set in ‘layers’ argument.')
   }
   layers <- Layers(object = x, search = layers)
   layers.split <- list()


### PR DESCRIPTION
As pointed out in this issue: https://github.com/satijalab/seurat/issues/7804 (with a useful reproducible example as well). 

Using pbmc3k: 
```
options(Seurat.object.assay.version = "v5")
pbmc3k <- LoadData("pbmc3k")
pbmc3k <- NormalizeData(pbmc3k)
pbmc3k <- ScaleData(pbmc3k)
random_values <- sample(c("a", "b"), nrow(pbmc3k@meta.data), replace = TRUE)
pbmc3k$random <- random_values
pbmc3k[["RNA"]] <- split(pbmc3k[["RNA"]], f = pbmc3k$random)
```
The scale.data layer will also be split:
```
Layers(pbmc3k)
[1] "counts.b"     "counts.a"     "data.b"       "data.a"       "scale.data.b" "scale.data.a"
```
If you ScaleData() again, you get a new plain scale.data layer
```
pbmc3k <- ScaleData(pbmc3k)
Layers(pbmc3k)
# [1] "counts.b"     "counts.a"     "data.b"       "data.a"       "scale.data.b" "scale.data.a" "scale.data"  
```
If you JoinLayers(), the scale.data is ignored
```
pbmc3k <- JoinLayers(pbmc3k)
Layers(pbmc3k)
# [1] "data"         "counts"       "scale.data.b" "scale.data.a" "scale.data"  
```

Ideally, we don't want ScaleData to be split at all, so now by default we just check "counts" and "data" and output this message: 
```
> pbmc3k[["RNA"]] <- split(pbmc3k[["RNA"]], f = pbmc3k$random)
Splitting 'counts' and 'data' layers by default. If you would like to split other layers, set in ‘layers’ argument.
> Layers(pbmc3k)
[1] "data.b"     "data.a"     "scale.data" "counts.b"   "counts.a"  
```

This gives the desired output here and in the reproducible example initially posted in the issue. 

I also updated some variable names. 

Updated output: 
```
> pbmc3k[["RNA"]] <- split(pbmc3k[["RNA"]], f = pbmc3k$random)
Splitting "counts, data" layers. Not splitting "scale.data". If you would like to split other layers, set in ‘layers’ argument.
> pbmc3k
An object of class Seurat 
13714 features across 2700 samples within 1 assay 
Active assay: RNA (13714 features, 0 variable features)
 5 layers present: counts.a, counts.b, scale.data, data.a, data.b
> pbmc3k[["RNA"]] <- split(pbmc3k[["RNA"]], f = pbmc3k$random)
Splitting "counts.a, counts.b, data.a, data.b" layers. Not splitting "scale.data". If you would like to split other layers, set in ‘layers’ argument.
Error in .local(x, f, drop, ...) :
The selected layers are already split: counts.a counts.b data.a data.b
Please join layers before splitting.
```