### PR TITLE
Draft: Fixing v5 VariableFeatures

### DIFF
--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1511,25 +1511,26 @@ VariableFeatures.StdAssay <- function(
 ) {
   nfeatures <- nfeatures %||% Inf
   if ("var.features" %in% colnames(object[])) {
-    rank.cols <- grep("rank", colnames(object[]), value = TRUE)
-    # find which indices are current variable features
-    var.features.indices <- which(!is.na(object["var.features"]))
-    # assumes only one column will match 
-    matching_results <- sapply(rank.cols, function(col) {
-      indices = which(!is.na(object[col]))
-      if (length(indices) != length(var.features.indices)) return(FALSE)
-      return(all(indices == var.features.indices))
-    })
-    if (all(matching_results == FALSE)){
-      var.features <- as.vector(object['var.features', drop = TRUE])
-      var.features <- var.features[!is.na(var.features)]
-      return(var.features)
-    }
-    # which method's rank matches the variable features indices
-    current.method.rank <- names(matching_results)[matching_results]
-    # sort 
-    var.features <- row.names(x = object[])[which(!is.na(object[]$var.features))]
-    var.features <- var.features[order(object[][[current.method.rank]][which(!is.na(object[]$var.features))])]
+    # rank.cols <- grep("rank", colnames(object[]), value = TRUE)
+    # # find which indices are current variable features
+    # var.features.indices <- which(!is.na(object["var.features"]))
+    # # assumes only one column will match 
+    # matching_results <- sapply(rank.cols, function(col) {
+    #   indices = which(!is.na(object[col]))
+    #   if (length(indices) != length(var.features.indices)) return(FALSE)
+    #   return(all(indices == var.features.indices))
+    # })
+    # if (all(matching_results == FALSE)){
+    #   var.features <- as.vector(object['var.features', drop = TRUE])
+    #   var.features <- var.features[!is.na(var.features)]
+    #   return(var.features)
+    # }
+    # # which method's rank matches the variable features indices
+    # current.method.rank <- names(matching_results)[matching_results]
+    # # sort 
+    var.features <- row.names(x = object[])[which(!is.na(object[]$var.features.rank))]
+    var.features <- var.features[order(object[][['var.features.rank']][which(!is.na(object[]$var.features))])]
+    
     if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) & 
         (is.infinite(x = nfeatures) || length(x = var.features) == 
          nfeatures)) {
@@ -1630,12 +1631,17 @@ VariableFeatures.Assay5 <- VariableFeatures.StdAssay
   value <- intersect(x = value, y = rownames(x = object))
   if (length(x = value) == 0) {
     object['var.features'] <- NA
+    object['var.features.rank'] <- NA
     return(object)
   }
   # if (!length(x = value)) {
   #   stop("None of the features specified are present in this assay", call. = FALSE)
   # }
   object['var.features'] <- value
+  # add rank 
+  object['var.features.rank'] <- NA
+  object[][row.names(object[]) %in% value,]$var.features.rank <- match(row.names(object[])[row.names(object[]) %in% value], value)
+  
   # layer <- Layers(object = object, search = layer)
   # df <- data.frame(TRUE, seq_along(along.with = value), row.names = value)
   # for (lyr in layer) {

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1563,10 +1563,12 @@ VariableFeatures.StdAssay <- function(
         abort(message = msg)
       }
       if (isTRUE(x = simplify)) {
+        # Pull layers that have values for VariableFeatures only
+        layers.vf <- names(vf)[sapply(vf, function(x) !is.na(x[1]))]
         vf <- .SelectFeatures(
           object = vf,
           all.features = intersect(
-            x = slot(object = object, name = 'features')[, layer]
+            x = slot(object = object, name = 'features')[, layers.vf]
           ),
           nfeatures = nfeatures
         )

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1509,15 +1509,26 @@ VariableFeatures.StdAssay <- function(
   ...
 ) {
   nfeatures <- nfeatures %||% Inf
-  if ('var.features' %in% colnames(object[])) {
-    var.features <- as.vector(object['var.features', drop = TRUE])
-    var.features <- var.features[!is.na(var.features)]
-    if (isTRUE(x = simplify) &
-        (is.null(x = layer) || any(is.na(x = layer)))&
-        (is.infinite(x = nfeatures) || length(x = var.features) == nfeatures)
-        ) {
-          return(var.features)
-        }
+  if ("var.features" %in% colnames(object[])) {
+    rank.cols <- grep("rank", colnames(object[]), value = TRUE)
+    # find which indices are current variable features
+    var.features.indices <- which(!is.na(object["var.features"]))
+    # assumes only one column will match 
+    matching_results <- sapply(rank.cols, function(col) {
+      indices = which(!is.na(object[col]))
+      if (length(indices) != length(var.features.indices)) return(FALSE)
+      return(all(indices == var.features.indices))
+    })
+    # which method's rank matches the variable features indices
+    current.method.rank <- names(matching_results)[matching_results]
+    # sort 
+    var.features <- row.names(x = object[])[which(!is.na(object[]$var.features))]
+    var.features <- var.features[order(object[][[current.method.rank]][which(!is.na(object[]$var.features))])]
+    if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) & 
+        (is.infinite(x = nfeatures) || length(x = var.features) == 
+         nfeatures)) {
+      return(var.features)
+    }
   }
       msg <- 'No variable features found'
       layer.orig <- layer

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -2603,20 +2603,21 @@ RenameCells.StdAssay <- function(object, new.names = NULL, ...) {
   )
   # Extract methods and layers
   vf.methods.layers <- lapply(vf.cols, function(col) {
-    components <- strsplit(col, split = '_')[[1]]
+    components <- strsplit(col, split = "_")[[1]]
     method <- components[2]
-    layer <- paste(components[3:(length(components) - 1)], collapse = '_')
+    layer <- paste(components[3:(length(components) - 1)], collapse = "_")
     return(c(method = method, layer = layer))
   })
   
-  # Combine them into a list
-  vf.list <- lapply(unique(unlist(lapply(vf.methods.layers, `[[`, 'method'))), function(method) {
+  # Combine into a list
+  vf.list <- lapply(unique(unlist(lapply(vf.methods.layers, `[[`, "method"))), function(method) {
     layers <- unique(unlist(lapply(vf.methods.layers, function(x) {
-      if(x['method'] == method) return(x['layer'])
+      if (x["method"] == method) 
+        return(x["layer"])
     })))
     return(setNames(list(layers), method))
   })
-  vf.list<- unlist(vf.list, use.names = TRUE)
+  vf.list <- Reduce(modifyList, vf.list)
   if (!length(x = vf.list)) {
     vf.list <- NULL
   }

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -931,12 +931,13 @@ HVFInfo.StdAssay <- function(
   ...
 ) {
   # Find available HVF methods and layers
-  vf.methods <- .VFMethods(object = object, type = 'hvf')
-  vf.layers <- .VFLayers(object = object, type = 'hvf')
+  vf.methods.layers <- .VFMethodsLayers(object = object, type = 'hvf')
+  #vf.methods <- .VFMethods(object = object, type = 'hvf')
+  #vf.layers <- .VFLayers(object = object, type = 'hvf')
   # Determine which method and layer to use
-  method <- (method %||% vf.methods)[1L]
+  method <- method[1L] %||% names(vf.methods.layers[1L]) 
   method <- tryCatch(
-    expr = match.arg(arg = method, choices = vf.methods),
+    expr = match.arg(arg = method, choices = names(vf.methods.layers)),
     error = function(...) {
       return(NULL)
     }
@@ -945,8 +946,8 @@ HVFInfo.StdAssay <- function(
   if (is.null(x = method)) {
     return(method)
   }
-  layer <- (layer %||% vf.layers)[1L]
-  layer <- vf.layers[which.min(x = adist(x = layer, y = vf.layers))]
+  layer <- layer %||% unname(vf.methods.layers[method])
+  #layer <- unname(vf.methods.layers)[which.min(x = adist(x = layer, y = unname(vf.methods.layers[method])))]
   # Find the columns for the specified method and layer
   cols <- grep(
     pattern = paste0(paste('^vf', method, layer, sep = '_'), '_'),
@@ -2488,6 +2489,7 @@ RenameCells.StdAssay <- function(object, new.names = NULL, ...) {
       return(paste(x[3L:(length(x = x) - 1L)], collapse = '_'))
     }
   )))
+  
   if (!isTRUE(x = missing)) {
     vf.layers <- intersect(
       x = vf.layers,
@@ -2556,6 +2558,75 @@ RenameCells.StdAssay <- function(object, new.names = NULL, ...) {
   }
   return(vf.methods)
 }
+
+#' @param object A \code{\link{StdAssay}} object
+#' @param type Type of variable feature method to pull; choose from:
+#' \itemize{
+#'  \item \dQuote{\code{hvf}}: highly variable features
+#'  \item \dQuote{\code{svf}}: spatially variable features
+#' }
+#' @param layers Vector of layers to restrict methods for, or a search pattern
+#' for multiple layers
+#'
+#' @return A vector of variable feature methods and corresponding layers found in \code{object}
+#'
+#' @noRd
+#'
+.VFMethodsLayers <- function(
+  object,
+  type = c('hvf', 'svf'),
+  layers = NA,
+  missing = FALSE
+) {
+  type <- type[1L]
+  type <- match.arg(arg = type)
+  pattern <- switch(
+    EXPR = type,
+    'hvf' = '^vf_',
+    abort(message = paste("Unknown type:", sQuote(x = type)))
+  )
+  vf.cols <- grep(
+    pattern = paste0(pattern, '[[:alnum:]]+_'),
+    x = colnames(x = object[]),
+    value = TRUE
+  )
+  # layers <- Layers(object = object, search = layers)
+  layers <- .VFLayers(
+    object = object,
+    type = type,
+    layers = layers,
+    missing = missing
+  )
+  vf.cols <- Filter(
+    f = function(x) {
+      x <- unlist(x = strsplit(x = x, split = '_'))
+      x <- paste(x[3:(length(x = x) - 1L)], collapse = '_')
+      return(x %in% layers)
+    },
+    x = vf.cols
+  )
+  # Extract methods and layers
+  vf.methods.layers <- lapply(vf.cols, function(col) {
+    components <- strsplit(col, split = '_')[[1]]
+    method <- components[2]
+    layer <- paste(components[3:(length(components) - 1)], collapse = '_')
+    return(c(method = method, layer = layer))
+  })
+  
+  # Combine them into a list
+  vf.list <- lapply(unique(unlist(lapply(vf.methods.layers, `[[`, 'method'))), function(method) {
+    layers <- unique(unlist(lapply(vf.methods.layers, function(x) {
+      if(x['method'] == method) return(x['layer'])
+    })))
+    return(setNames(list(layers), method))
+  })
+  vf.list<- unlist(vf.list, use.names = TRUE)
+  if (!length(x = vf.list)) {
+    vf.list <- NULL
+  }
+  return(vf.list)
+}
+
 
 CalcN5 <- function(object) {
   if (IsMatrixEmpty(x = LayerData(object = object))) {

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -947,7 +947,7 @@ HVFInfo.StdAssay <- function(
     return(method)
   }
   layer <- layer %||% unname(vf.methods.layers[method])
-  #layer <- unname(vf.methods.layers)[which.min(x = adist(x = layer, y = unname(vf.methods.layers[method])))]
+  layer <- unname(vf.methods.layers)[which.min(x = adist(x = layer, y = unname(vf.methods.layers[method])))]
   # Find the columns for the specified method and layer
   cols <- grep(
     pattern = paste0(paste('^vf', method, layer, sep = '_'), '_'),

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -947,7 +947,7 @@ HVFInfo.StdAssay <- function(
     return(method)
   }
   layer <- layer %||% unname(vf.methods.layers[method])
-  layer <- unname(vf.methods.layers)[which.min(x = adist(x = layer, y = unname(vf.methods.layers[method])))]
+  # layer <- unname(vf.methods.layers)[which.min(x = adist(x = layer, y = unname(vf.methods.layers[method])))]
   # Find the columns for the specified method and layer
   cols <- grep(
     pattern = paste0(paste('^vf', method, layer, sep = '_'), '_'),
@@ -1511,26 +1511,14 @@ VariableFeatures.StdAssay <- function(
 ) {
   nfeatures <- nfeatures %||% Inf
   if ("var.features" %in% colnames(object[])) {
-    # rank.cols <- grep("rank", colnames(object[]), value = TRUE)
-    # # find which indices are current variable features
-    # var.features.indices <- which(!is.na(object["var.features"]))
-    # # assumes only one column will match 
-    # matching_results <- sapply(rank.cols, function(col) {
-    #   indices = which(!is.na(object[col]))
-    #   if (length(indices) != length(var.features.indices)) return(FALSE)
-    #   return(all(indices == var.features.indices))
-    # })
-    # if (all(matching_results == FALSE)){
-    #   var.features <- as.vector(object['var.features', drop = TRUE])
-    #   var.features <- var.features[!is.na(var.features)]
-    #   return(var.features)
-    # }
-    # # which method's rank matches the variable features indices
-    # current.method.rank <- names(matching_results)[matching_results]
-    # # sort 
-    var.features <- row.names(x = object[])[which(!is.na(object[]$var.features.rank))]
-    var.features <- var.features[order(object[][['var.features.rank']][which(!is.na(object[]$var.features))])]
-    
+    if ("var.features.rank" %in% colnames(object[])) {
+      var.features <- row.names(x = object[])[which(!is.na(object[]$var.features.rank))]
+      var.features <- var.features[order(object[][["var.features.rank"]][which(!is.na(object[]$var.features))])]
+    }
+    else {
+      var.features <- as.vector(object["var.features", drop = TRUE])
+      var.features <- var.features[!is.na(var.features)]
+    }
     if (isTRUE(x = simplify) & (is.null(x = layer) || any(is.na(x = layer))) & 
         (is.infinite(x = nfeatures) || length(x = var.features) == 
          nfeatures)) {

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -724,7 +724,7 @@ FetchData.StdAssay <- function(
     ))
   }
   if (is.null(layer.set)) {
-  stop('layer ', layer,' is not found in the object')
+  stop('layer "', layer,'" is not found in the object')
   } else {
     layer <- layer.set
     }

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1519,6 +1519,11 @@ VariableFeatures.StdAssay <- function(
       if (length(indices) != length(var.features.indices)) return(FALSE)
       return(all(indices == var.features.indices))
     })
+    if (all(matching_results == FALSE)){
+      var.features <- as.vector(object['var.features', drop = TRUE])
+      var.features <- var.features[!is.na(var.features)]
+      return(var.features)
+    }
     # which method's rank matches the variable features indices
     current.method.rank <- names(matching_results)[matching_results]
     # sort 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -2104,13 +2104,28 @@ HVFInfo.Seurat <- function(
   method = NULL,
   status = FALSE,
   assay = NULL,
-  selection.method = method,
+  selection.method = deprecated(),
   ...
 ) {
   CheckDots(...)
+  if (is_present(arg = selection.method)) {
+    f <- if (.IsFutureSeurat(version = '5.1.0')) {
+      deprecate_stop
+    } else if (.IsFutureSeurat(version = '5.0.0')) {
+      deprecate_warn
+    } else {
+      deprecate_soft
+    }
+    f(
+      when = '5.0.0',
+      what = 'HVFInfo(selection.method = )',
+      with = 'HVFInfo(method = )'
+    )
+    method <- selection.method
+  }
   object <- UpdateSlots(object = object)
   assay <- assay %||% DefaultAssay(object = object)
-  if (is.null(x = selection.method)) {
+  if (is.null(x = method)) {
     cmds <- apply(
       X = expand.grid(
         c('FindVariableFeatures', 'SCTransform'),
@@ -2134,7 +2149,7 @@ HVFInfo.Seurat <- function(
       yes = test.command,
       no = find.command
     )
-    selection.method <- switch(
+    method <- switch(
       EXPR = file_path_sans_ext(x = find.command),
       'FindVariableFeatures' = Command(
         object = object,
@@ -2147,7 +2162,7 @@ HVFInfo.Seurat <- function(
   }
   return(HVFInfo(
     object = object[[assay]],
-    selection.method = selection.method,
+    method = method,
     status = status
   ))
 }


### PR DESCRIPTION
When we run VariableFeatures.StdAssay(), we are not sorting by rank. We also have no way of storing which VariableFeatures method was last run, if you run multiple versions (vst, mvp for example).

As a current fix, this:
adds a new column to the feature level metadata called var.features.rank
sorts variable features based on that ranking
Also fixes VariableFeaturePlot

If we've run FindVariableFeatures multiple times with different methods:
In HVFInfo.StdAssay, we just pull the first layer, which is not necessarily the one that corresponds with the method that was run.
For example, we can end up with 'vst' and 'data' when it should be 'vst' and 'counts'
I created a function to pair the method and layer
VariableFeature() .SelectFeatures() bug with layers that have less features

if there is a scale.data layer, FindVariableFeatures filters out any features that aren't also in that layer.
[FindVariableFeatures tests](https://github.com/satijalab/seurat-private/blob/a8d3fce9edd91ca89af2ec5e08707f9903ccaa90/tests/testthat/test_preprocessing.R#L300C1-L307C3) with v5 assay are failing because of this
this would happen if you have any layers that have less features than the others
Current fix: only pull features from layers that have features found.
Another option: just pull from all features in the object, do we really have to filter here?

TO DO:

adist() leads to some issues