### PR TITLE
Adjust relocation of on-disk layers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.0.9002
+Version: 5.0.0.9003
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Paul', family = 'Hoffman', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Changes:
 - Update internal calls to `GetAssayData()` to use `layer` instead of `slot` (#160)
+- Change layer-saving in `SaveSeuratRds()` to move all layers instead of just those in `tempdir()` (#169)
 
 # SeuratObject 5.0.0
 ## Added

--- a/R/utils.R
+++ b/R/utils.R
@@ -2276,7 +2276,11 @@ StitchMatrix.matrix <- function(x, y, rowmap, colmap, ...) {
     new_path <- fs::path_expand(path = new_path)
     new_path <- fs::dir_create(path = new_path)
     dest <- tryCatch(
-      expr = fs::dir_copy(path = path, new_path = new_path, overwrite = overwrite),
+      expr = fs::dir_copy(
+        path = path,
+        new_path = new_path,
+        overwrite = overwrite
+      ),
       EEXIST = eexist,
       error = hndlr
     )
@@ -2292,10 +2296,13 @@ StitchMatrix.matrix <- function(x, y, rowmap, colmap, ...) {
     )
   } else {
     abort(
-      message = paste0(
-        "Can't find path: ",
-        sQuote(x = path),
-        "; if path is relative, change working directory."
+      message = paste(
+        strwrap(x = paste0(
+          "Can't find path: ",
+          sQuote(x = path),
+          "; if path is relative, change working directory"
+        )),
+        sep = '\n'
       ),
       call = caller_env(n = 1L + n)
     )

--- a/man/SaveSeuratRds.Rd
+++ b/man/SaveSeuratRds.Rd
@@ -5,7 +5,14 @@
 \alias{LoadSeuratRds}
 \title{Save and Load \code{Seurat} Objects from Rds files}
 \usage{
-SaveSeuratRds(object, file = NULL, destdir = NULL, relative = FALSE, ...)
+SaveSeuratRds(
+  object,
+  file = NULL,
+  move = TRUE,
+  destdir = deprecated(),
+  relative = FALSE,
+  ...
+)
 
 LoadSeuratRds(file, ...)
 }
@@ -15,8 +22,9 @@ LoadSeuratRds(file, ...)
 \item{file}{Path to save \code{object} to; defaults to
 \code{file.path(getwd(), paste0(Project(object), ".Rds"))}}
 
-\item{destdir}{Destination directory for on-disk layers saved in
-\dQuote{\code{\Sexpr[stage=render]{tempdir()}}}}
+\item{move}{Move on-disk layers into \code(dirname(file))}
+
+\item{destdir}{\Sexpr[stage=build,results=rd]{lifecycle::badge("deprecated")}}
 
 \item{relative}{Save relative paths instead of absolute ones}
 


### PR DESCRIPTION
Adjust relocation on-disk layers in `SaveSeuratRds()` to always move on-disk layers into `dirname(file)` regardless of whether a layer is in `tempdir()` or not. Deprecate `destdir` in favor of `move`