### PR TITLE
Two fixes to no longer use deprecated routines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SeuratObject
 Type: Package
 Title: Data Structures for Single Cell Data
-Version: 5.0.0.9003
+Version: 5.0.0.9004
 Authors@R: c(
   person(given = 'Rahul', family = 'Satija', email = 'rsatija@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0001-9448-8833')),
   person(given = 'Paul', family = 'Hoffman', email = 'seurat@nygenome.org', role = c('aut', 'cre'), comment = c(ORCID = '0000-0002-7693-8957')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Changes:
 - Update internal calls to `GetAssayData()` to use `layer` instead of `slot` (#160)
 - Change layer-saving in `SaveSeuratRds()` to move all layers instead of just those in `tempdir()` (#169)
+- Update internal calls to `SetAssayData()` to use `layer` instead of `slot` (#171)
+- Replace internal calls of `FilterObjects()` to `.FilterObjects()` (#171)
 
 # SeuratObject 5.0.0
 ## Added

--- a/R/assay5.R
+++ b/R/assay5.R
@@ -1518,7 +1518,7 @@ SetAssayData.StdAssay <- function(
     )
     layer <- slot
   }
-  LayerData(object = object, layer = slot) <- new.data
+  LayerData(object = object, layer = layer) <- new.data
   return(object)
 }
 

--- a/R/seurat.R
+++ b/R/seurat.R
@@ -474,7 +474,6 @@ Neighbors <- function(object, slot = NULL) {
 #' Reductions(object = pbmc_small)
 #'
 Reductions <- function(object, slot = NULL) {
-  # reductions <- FilterObjects(object = object, classes.keep = 'DimReduc')
   reductions <- .FilterObjects(object = object, classes.keep = 'DimReduc')
   if (is.null(x = slot)) {
     return(reductions)
@@ -900,7 +899,7 @@ UpdateSeuratObject <- function(object) {
       object <- UpdateSlots(object = object)
       # Validate object keys
       message("Ensuring keys are in the proper structure")
-      for (ko in FilterObjects(object = object)) {
+      for (ko in .FilterObjects(object = object)) {
         key <- Key(object = object[[ko]])
         if (!length(x = key) || !nzchar(x = key)) {
           key <- Key(object = ko, quiet = TRUE)
@@ -931,7 +930,7 @@ UpdateSeuratObject <- function(object) {
       assays <- make.names(names = Assays(object = object))
       names(x = assays) <- Assays(object = object)
       object <- do.call(what = RenameAssays, args = c('object' = object, assays))
-      for (obj in FilterObjects(object = object, classes.keep = c('Assay', 'DimReduc', 'Graph'))) {
+      for (obj in .FilterObjects(object = object, classes.keep = c('Assay', 'DimReduc', 'Graph'))) {
         suppressWarnings(
           expr = object[[obj]] <- UpdateSlots(object = object[[obj]]),
           classes = 'validationWarning'
@@ -944,7 +943,7 @@ UpdateSeuratObject <- function(object) {
       }
       # Validate object keys
       message("Ensuring keys are in the proper structure")
-      for (ko in FilterObjects(object = object)) {
+      for (ko in .FilterObjects(object = object)) {
         suppressWarnings(
           expr = Key(object = object[[ko]]) <- UpdateKey(key = Key(object = object[[ko]])),
           classes = 'validationWarning'
@@ -952,7 +951,7 @@ UpdateSeuratObject <- function(object) {
       }
       # Check feature names
       message("Ensuring feature names don't have underscores or pipes")
-      for (assay.name in FilterObjects(object = object, classes.keep = 'Assay')) {
+      for (assay.name in .FilterObjects(object = object, classes.keep = 'Assay')) {
         assay <- object[[assay.name]]
         for (slot in c('counts', 'data', 'scale.data')) {
           if (!IsMatrixEmpty(x = slot(object = assay, name = slot))) {
@@ -1005,7 +1004,7 @@ UpdateSeuratObject <- function(object) {
           classes = 'validationWarning'
         )
       }
-      for (reduc.name in FilterObjects(object = object, classes.keep = 'DimReduc')) {
+      for (reduc.name in .FilterObjects(object = object, classes.keep = 'DimReduc')) {
         reduc <- object[[reduc.name]]
         for (slot in c('feature.loadings', 'feature.loadings.projected')) {
           if (!IsMatrixEmpty(x = slot(object = reduc, name = slot))) {
@@ -1433,7 +1432,7 @@ DefaultAssay.Seurat <- function(object, ...) {
 #'
 DefaultFOV.Seurat <- function(object, assay = NULL, ...) {
   assay <- assay[1L] %||% DefaultAssay(object = object)
-  fovs <- FilterObjects(object = object, classes.keep = 'FOV')
+  fovs <- .FilterObjects(object = object, classes.keep = 'FOV')
   if (is.na(x = assay)) {
     return(fovs[1L])
   }
@@ -1463,7 +1462,7 @@ DefaultFOV.Seurat <- function(object, assay = NULL, ...) {
 #'
 "DefaultFOV<-.Seurat" <- function(object, assay = NA, ..., value) {
   assay <- assay[1L] %||% DefaultAssay(object = object)
-  fovs <- FilterObjects(object = object, classes.keep = 'FOV')
+  fovs <- .FilterObjects(object = object, classes.keep = 'FOV')
   value <- match.arg(arg = value, choices = fovs)
   if (!is.na(x = assay)) {
     assay <- match.arg(arg = assay, choices = Assays(object = object))
@@ -1975,7 +1974,7 @@ HVFInfo.Seurat <- function(
     cmds <- apply(
       X = expand.grid(
         c('FindVariableFeatures', 'SCTransform'),
-        FilterObjects(object = object, classes.keep = c('Assay', 'Assay5'))
+        .FilterObjects(object = object, classes.keep = c('Assay', 'Assay5'))
       ),
       MARGIN = 1,
       FUN = paste,
@@ -2366,7 +2365,7 @@ RenameCells.Seurat <- function(
   Idents(object = object) <- old.ids
   names(x = new.cell.names) <- old.names
   # rename in the assay objects
-  assays <- FilterObjects(object = object, classes.keep = 'Assay')
+  assays <- .FilterObjects(object = object, classes.keep = 'Assay')
   for (i in assays) {
     slot(object = object, name = "assays")[[i]] <- RenameCells(
       object = object[[i]],
@@ -2374,7 +2373,7 @@ RenameCells.Seurat <- function(
     )
   }
   # rename in the assay5 objects
-  assays5 <- FilterObjects(object = object, classes.keep = 'Assay5')
+  assays5 <- .FilterObjects(object = object, classes.keep = 'Assay5')
   for (i in assays5) {
     slot(object = object, name = "assays")[[i]] <- RenameCells(
       object = object[[i]],
@@ -2382,7 +2381,7 @@ RenameCells.Seurat <- function(
     )
   }
   # rename in the DimReduc objects
-  dimreducs <- FilterObjects(object = object, classes.keep = 'DimReduc')
+  dimreducs <- .FilterObjects(object = object, classes.keep = 'DimReduc')
   for (i in dimreducs) {
     slot(object = object, name = "reductions")[[i]] <- RenameCells(
       object = object[[i]],
@@ -2390,7 +2389,7 @@ RenameCells.Seurat <- function(
     )
   }
   # rename the graphs
-  graphs <- FilterObjects(object = object, classes.keep = "Graph")
+  graphs <- .FilterObjects(object = object, classes.keep = "Graph")
   for (g in graphs) {
     graph.g <- object[[g]]
     rownames(graph.g) <- colnames(graph.g) <- new.cell.names[colnames(x = graph.g)]
@@ -2477,8 +2476,8 @@ SetAssayData.Seurat <- function(
   if (is_present(arg = slot)) {
     .Deprecate(
       when = '5.0.0',
-      what = 'GetAssayData(slot = )',
-      with = 'GetAssayData(layer = )'
+      what = 'SetAssayData(slot = )',
+      with = 'SetAssayData(layer = )'
     )
     layer <- slot
   }
@@ -2771,7 +2770,7 @@ WhichCells.Seurat <- function(
     cells <- intersect(x = cells, y = cells.idents)
   }
   if (!missing(x = expression)) {
-    objects.use <- FilterObjects(
+    objects.use <- .FilterObjects(
       object = object,
       classes.keep = c('Assay', 'StdAssay', 'DimReduc', 'SpatialImage')
     )
@@ -3750,11 +3749,11 @@ subset.Seurat <- function(
     f = Negate(f = is.null),
     x = slot(object = x, name = 'assays')
   )
-  if (length(x = FilterObjects(object = x, classes.keep = c('Assay', 'StdAssay'))) == 0 || is.null(x = x[[DefaultAssay(object = x)]])) {
+  if (length(x = .FilterObjects(object = x, classes.keep = c('Assay', 'StdAssay'))) == 0 || is.null(x = x[[DefaultAssay(object = x)]])) {
     abort(message = "Under current subsetting parameters, the default assay will be removed. Please adjust subsetting parameters or change default assay")
   }
   # Filter DimReduc objects
-  for (dimreduc in FilterObjects(object = x, classes.keep = 'DimReduc')) {
+  for (dimreduc in .FilterObjects(object = x, classes.keep = 'DimReduc')) {
     suppressWarnings(
       x[[dimreduc]] <- tryCatch(
         expr = subset.DimReduc(x = x[[dimreduc]], cells = cells, features = features),
@@ -3770,7 +3769,7 @@ subset.Seurat <- function(
   }
   # Recalculate nCount and nFeature
   if (!is.null(features)) {
-    for (assay in FilterObjects(object = x, classes.keep = 'Assay')) {
+    for (assay in .FilterObjects(object = x, classes.keep = 'Assay')) {
       n.calc <- CalcN(object = x[[assay]])
       if (!is.null(x = n.calc)) {
         names(x = n.calc) <- paste(names(x = n.calc), assay, sep = '_')

--- a/R/utils.R
+++ b/R/utils.R
@@ -267,7 +267,7 @@ NULL
 #' @concept utils
 #'
 .DefaultFOV <- function(object, assay = NULL) {
-  images <- FilterObjects(object = object, classes.keep = 'FOV')
+  images <- .FilterObjects(object = object, classes.keep = 'FOV')
   if (!is.null(x = assay)) {
     assays <- c(assay, DefaultAssay(object = object[[assay]]))
     images <- Filter(
@@ -1011,7 +1011,7 @@ DefaultDimReduc <- function(object, assay = NULL) {
   object <- UpdateSlots(object = object)
   assay <- assay %||% DefaultAssay(object = object)
   drs.use <- c('umap', 'tsne', 'pca')
-  dim.reducs <- FilterObjects(object = object, classes.keep = 'DimReduc')
+  dim.reducs <- .FilterObjects(object = object, classes.keep = 'DimReduc')
   drs.assay <- Filter(
     f = function(x) {
       return(DefaultAssay(object = object[[x]]) == assay)


### PR DESCRIPTION
Replace use of `slot` with `layer` in `SetAssayData.StdAssay()` Replace use of `FilterObjects()` with `.FilterObjects()